### PR TITLE
Allow multiple tasks

### DIFF
--- a/src/fabric.coffee
+++ b/src/fabric.coffee
@@ -27,6 +27,7 @@
 #       "top"
 #     ],
 #     "prefix": "",
+#     "surround_with": "",
 #     "role": "fabric"
 #   }
 #
@@ -43,6 +44,16 @@
 #     For instance, HipChat supports "/quote " to display messages in a fixed-width
 #     format. Thus, you can set "prefix": "/quote " to apply this formatter to
 #     fabric's output.
+#
+#     Note that you cannot combine "prefix" with "surround_with". If you define a
+#     prefix, the "surround_with" argument will be ignored.
+#   - "surround_with" (string) (Optional) Used to format fabric's output. Similar
+#     to "prefix", but allows an identical string to be used as both a prefix and a
+#     suffix.
+#
+#     For instance, Slack supports "```preformatted```" to display messages in a
+#     fixed-width. Thus, you can set "surround_with": "```" to apply this formatter
+#     to fabric's output.
 #   - "role" (String) (Optional) Uses the [hubot-auth][1] module (requires
 #     installation) for restricting access via user configurable roles.
 #
@@ -90,6 +101,9 @@ module.exports = (robot) ->
   formatOutput = (text) ->
     if CONFIG.prefix?
       return CONFIG.prefix + text
+    # FIXME: doesn't work with very long messages in Slack
+    else if CONFIG.surround_with
+      return CONFIG.surround_with + text + CONFIG.surround_with
     return text
 
   buildArgs = (task, host) ->

--- a/src/fabric.coffee
+++ b/src/fabric.coffee
@@ -27,7 +27,7 @@
 #       "top"
 #     ],
 #     "prefix": "",
-#     "surround_with": "",
+#     "suffix": "",
 #     "role": "fabric"
 #   }
 #
@@ -45,15 +45,12 @@
 #     format. Thus, you can set "prefix": "/quote " to apply this formatter to
 #     fabric's output.
 #
-#     Note that you cannot combine "prefix" with "surround_with". If you define a
-#     prefix, the "surround_with" argument will be ignored.
-#   - "surround_with" (string) (Optional) Used to format fabric's output. Similar
-#     to "prefix", but allows an identical string to be used as both a prefix and a
-#     suffix.
+#   - "suffix" (string) (Optional) Used to format fabric's output. Similar
+#     to "prefix", but appends to the end of the output.
 #
-#     For instance, Slack supports "```preformatted```" to display messages in a
-#     fixed-width. Thus, you can set "surround_with": "```" to apply this formatter
-#     to fabric's output.
+#     Useful for services like Slack that support "```preformatted```" to display
+#     messages in a fixed-width. Thus, you can set both "prefix" and "suffix" to
+#     "```" to apply this formatting to fabric's output.
 #   - "role" (String) (Optional) Uses the [hubot-auth][1] module (requires
 #     installation) for restricting access via user configurable roles.
 #
@@ -102,8 +99,8 @@ module.exports = (robot) ->
     if CONFIG.prefix?
       return CONFIG.prefix + text
     # FIXME: doesn't work with very long messages in Slack
-    else if CONFIG.surround_with
-      return CONFIG.surround_with + text + CONFIG.surround_with
+    if CONFIG.suffix?
+      return text + CONFIG.suffix
     return text
 
   buildArgs = (tasks, host) ->

--- a/src/fabric.coffee
+++ b/src/fabric.coffee
@@ -106,7 +106,7 @@ module.exports = (robot) ->
       return CONFIG.surround_with + text + CONFIG.surround_with
     return text
 
-  buildArgs = (task, host) ->
+  buildArgs = (tasks, host) ->
     args = []
 
     args.push "-i#{CONFIG.auth}" if CONFIG.auth?
@@ -114,18 +114,19 @@ module.exports = (robot) ->
     args.push "#{host}"
     args.push "-u#{CONFIG.user}" if CONFIG.user?
     args.push "-p#{CONFIG.pass}" if CONFIG.pass?
-    args.push task
+    args.push tasks
 
     return args
 
-  buildCmd = (task, host) ->
+  buildCmd = (tasks, host) ->
+    tasks = tasks.join(" ")
     cmd = "#{CONFIG.path}"
     cmd += " -i#{CONFIG.auth}" if CONFIG.auth?
     cmd += " -f#{CONFIG.file}" if CONFIG.file?
     cmd += " #{host}"
     cmd += " -u#{CONFIG.user}" if CONFIG.user?
     cmd += " -p#{CONFIG.pass}" if CONFIG.pass?
-    cmd += " #{task}"
+    cmd += " #{tasks}"
 
     return cmd
 
@@ -141,10 +142,12 @@ module.exports = (robot) ->
 
     return robot.auth.hasRole(user, role)
 
-  executeTask = (msg, method, task, host) ->
-    if not isTaskValid(task)
-      msg.send "Unauthorized task: #{task}"
-      return
+  executeTask = (msg, method, tasks, host) ->
+    tasks = tasks.split(' ')
+    for singleTask in tasks
+      if not isTaskValid(singleTask)
+        msg.send "Unauthorized task: #{singleTask}"
+        return
 
     user = msg.envelope.user
     role = CONFIG.role
@@ -154,18 +157,23 @@ module.exports = (robot) ->
       return
 
     if method is 'exec'
-      cmd = buildCmd(task, host)
+      cmd = buildCmd(tasks, host)
       exec(msg, cmd)
     else if method is 'spawn'
       cmd = CONFIG.path
-      args = buildArgs(task, host)
+      args = buildArgs(tasks, host)
       spawn(msg, cmd, args)
 
-  robot.respond /fabric (exec|spawn)? ?(-H) ?([\w.\-_]+) (.+)/i, (msg) ->
+  robot.respond ///
+    fabric\s                           # fabric followed by a space
+    (exec|spawn)?\s?                   # exec and spawn are optional; default to exec
+    (-H ?[\w.\-_]+|host:[\w.\-_]+)+\s  # Host can be defined with -Hhostname or host:hostname
+    (.+)                               # The rest is tasks, which do get validated
+  ///i, (msg) ->
     method = msg.match[1] ||= 'exec'
-    host = msg.match[2] + msg.match[3]
-    task = msg.match[4]
-    executeTask(msg, method, task, host)
+    host = msg.match[2]
+    tasks = msg.match[3]
+    executeTask(msg, method, tasks, host)
 
   robot.respond /fabric tasks/i, (msg) ->
     msg.send "Authorized fabric tasks: #{CONFIG.tasks}"

--- a/test/fabric-test.coffee
+++ b/test/fabric-test.coffee
@@ -116,3 +116,22 @@ describe 'fabric', ->
     adapter.receive(new TextMessage adminUser, "hubot fabric -Htest.example.com df")
     expect(cp.exec).to.be.calledOnce
     done()
+
+  it 'exec multiple tasks', (done) ->
+    adapter.receive(new TextMessage roleUser, "hubot fabric exec -Htest.example.com df free:foo")
+    expect(cp.exec).to.be.calledOnce
+    expect(cp.exec.args[0][0]).to.contain 'df free:foo'
+    done()
+
+  it 'attempt exec one forbidden task of many allowed', (done) ->
+    adapter.on "send", (envelope, strings) ->
+      expect(cp.exec).to.be.not.called
+      expect(strings[0]).to.contain 'Unauthorized task: forbidden'
+      done()
+
+    adapter.receive(new TextMessage roleUser, "hubot fabric exec -Htest.example.com df free:foo forbidden")
+
+  it 'use host: instead of -H', (done) ->
+    adapter.receive(new TextMessage roleUser, "hubot fabric host:dev df")
+    expect(cp.exec.args[0]).to.contain '/my/fab -i/my/ssh-key.pem -f/my/fabfile.py host:dev -uuser -ppass df'
+    done()


### PR DESCRIPTION
Add support for a `surround_with` configuration option. When defined, the output is formatted with the `surround_with` value at the beginning and end. This is helpful with tools like Slack that let users pre-format text by surrounding it with three backticks. 

This option cannot be used if the `prefix` option is used. In that case, only `prefix` is used.

Also, add support for calling multiple tasks simultaneously. Fabric lends well to a pattern of chaining tasks in a single call, like `fabric host:foo create_file:test.txt list_files`. This change set enables this behaviour.

Lastly, add support for specifying the host by using a `host` method in your fabfile. This pattern is useful if you need to define additional variables about your host, such as the FQDN, a default git branch for the host, etc..

My apologies about putting all three items into one PR. I can separate them if needed.