### PR TITLE
Add fabric_alias CONFIG option:

### DIFF
--- a/src/fabric.coffee
+++ b/src/fabric.coffee
@@ -17,6 +17,7 @@
 #     "path": "/my/virtualenv/bin/fab",
 #     "file": "/full/path/to/my/fabfile.py",
 #     "auth": "/full/path/to/my/ssh-key.pem",
+#     "fabric_alias": "fab",
 #     "user": "user",
 #     "pass": "pass",
 #     "tasks": [
@@ -34,6 +35,8 @@
 #   - "path" (String) Path to the fabric executable script
 #   - "file" (String) Path to the fabric file
 #   - "auth" (String) Path to the SSH private key file
+#   - "fabric_alias" (String) (Optional) The string to use for envoking Fabric.
+#      eg. "fab" or "fabric". Defaults to "fabric".
 #   - "user" (String) (Optional) User name to use when connecting to remote hosts
 #   - "pass" (String) (Optional) Password to use when connection to remote hosts
 #   - "tasks" (Array) Strings of fabric tasks that can be executed. Set to ["*"]
@@ -162,7 +165,7 @@ module.exports = (robot) ->
       spawn(msg, cmd, args)
 
   robot.respond ///
-    fabric\s                           # fabric followed by a space
+    #{CONFIG.fabric_alias}|fabric\s    # fabric followed by a space
     (exec|spawn)?\s?                   # exec and spawn are optional; default to exec
     (-H ?[\w.\-_]+|host:[\w.\-_]+)+\s  # Host can be defined with -Hhostname or host:hostname
     (.+)                               # The rest is tasks, which do get validated
@@ -172,5 +175,8 @@ module.exports = (robot) ->
     tasks = msg.match[3]
     executeTask(msg, method, tasks, host)
 
-  robot.respond /fabric tasks/i, (msg) ->
+  robot.respond ///
+    #{CONFIG.fabric_alias}|fabric\s
+    tasks
+  ///i, (msg) ->
     msg.send "Authorized fabric tasks: #{CONFIG.tasks}"

--- a/test/fabric-test.coffee
+++ b/test/fabric-test.coffee
@@ -20,7 +20,8 @@ CONFIG = """
     "free"
   ],
   "prefix": "",
-  "role": "fabric"
+  "role": "fabric",
+  "fabric_alias": "zarathustra"
 }
 """
 
@@ -134,4 +135,20 @@ describe 'fabric', ->
   it 'use host: instead of -H', (done) ->
     adapter.receive(new TextMessage roleUser, "hubot fabric host:dev df")
     expect(cp.exec.args[0]).to.contain '/my/fab -i/my/ssh-key.pem -f/my/fabfile.py host:dev -uuser -ppass df'
+    done()
+
+  it 'call fabric by alias', (done) ->
+    is_message_received = false
+    adapter.on "send", (envelope, strings) ->
+      expect(strings[0]).to.contain 'Authorized fabric tasks: df'
+      is_message_received = true
+
+    # not_fabric is not the alias or the default handle (fabric)
+    adapter.receive(new TextMessage adminUser, "hubot not_fabric tasks")
+    expect(is_message_received).to.not.be.true
+
+    # zarathustra is the alias, so hubot should respond
+    adapter.receive(new TextMessage adminUser, "hubot zarathustra tasks")
+    expect(is_message_received).to.be.true
+
     done()


### PR DESCRIPTION
Allows Fabric to be called by something other than `fabric`. If set, Fabric will always respond to `fabric` as well as the alias.

For example, if you set `"fabric_alias": "fab"`, `fab tasks` will produce the same result as `fabric tasks`.